### PR TITLE
Update getting-started.md

### DIFF
--- a/pages/user-guide/getting-started/getting-started.md
+++ b/pages/user-guide/getting-started/getting-started.md
@@ -22,7 +22,9 @@ Now, lets move to the process of signing up and deployment
 
 ![1](imgs/1.jpg)
 
-CloudPlex offers 3 ways of creation and application deployment on the cloud, based on the requirements and expertise level of the user. 
+# Start Creating Application - Infrastructure Types
+
+CloudPlex offers 3 ways of creation and application deployment on the cloud, based on the requirements. 
 
 1. Provider Managed
    To setup a cloud provider (AWS, Azure etc) managed Kubernetes cluster on CloudPlex.


### PR DESCRIPTION
we have covered all the cluster types and creation methodologies under getting started. I want to restructure it and after successful user registration and login procedure can we describe available application types which are basically cluster/infrastructure types under a separate heading, So that I can redirect any user to that article directly without explaining the login procedure when needed.